### PR TITLE
Make file linking and matching faster

### DIFF
--- a/Utils.cpp
+++ b/Utils.cpp
@@ -280,6 +280,10 @@ bool sce_junction::copy_existing_file(psvpfs::path source_root, psvpfs::path des
    return true;
 }
 
+const psvpfs::path &sce_junction::get_value() const {
+    return m_value;
+}
+
 std::ostream& operator<<(std::ostream& os, const sce_junction& p)
 {
    os << p.m_value.generic_string();

--- a/Utils.h
+++ b/Utils.h
@@ -76,6 +76,9 @@ public:
    //copy file with specific size in destination root using path from this junction
    bool copy_existing_file(psvpfs::path source_root, psvpfs::path destination_root, std::uintmax_t size) const;
 
+   //return corresponding virtual path
+   const psvpfs::path& get_value() const;
+
 public:
    //this operator should only be used for printing to console!
    friend std::ostream& operator<<(std::ostream& os, const sce_junction& p);


### PR DESCRIPTION
File linking and matching is really slow right now (for each virtual file it can look at all existing files in each step).

Use a map to make this process much faster (these steps in ciel nosurge offline installation went from taking around 1h30 to taking 0.6 seconds).